### PR TITLE
feat(docker): custom apache port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ SPIP_ADMIN_PASS=adminadmin
 SPIP_VERSION_SITE=thematique
 SPIP_PLUGINS_CICAS=false
 PROJET=laclasse
+APACHE_PORT=80

--- a/Dockerfile
+++ b/Dockerfile
@@ -194,7 +194,10 @@ ENV PHP_POST_MAX_SIZE 40M
 ENV PHP_UPLOAD_MAX_FILESIZE 32M
 ENV PHP_TIMEZONE Europe/Paris
 
-EXPOSE 80
+# Apache
+ENV APACHE_PORT 80
+
+EXPOSE ${APACHE_PORT}
 
 COPY ./plugins /usr/src/spip/plugins/
 COPY ./docker-entrypoint.sh /

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - MYSQL_PASSWORD=${SPIP_DB_PASS}
 
   app:
-    image: erasme/spip-ccn:helm
+    image: erasme/spip-ccn:custom-port
     restart: always
     env_file:
       - .env
@@ -26,4 +26,4 @@ services:
     links:
       - db:mysql
     ports:
-      - 8880:80
+      - 8005:80

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -49,6 +49,12 @@ echo 'upload_max_filesize=${PHP_UPLOAD_MAX_FILESIZE}'; \
 echo 'date.timezone=${PHP_TIMEZONE}'; \
 ) > /usr/local/etc/php/conf.d/spip.ini
 
+# Configure Apache port
+if [ "${APACHE_PORT}" != "80" ]; then
+    echo "Listen ${APACHE_PORT}" > /etc/apache2/ports.conf
+    sed -i "s/:80>/:${APACHE_PORT}>/g" /etc/apache2/sites-available/000-default.conf
+fi
+
 
 if version_greater "$image_version" "$installed_version"; then
 	echo >&2 "SPIP upgrade in $PWD - copying now..."


### PR DESCRIPTION
Possibilitée de changer le port apache au travers d'une variable d'environnement

Cette modification est nécessaire pour permettre l'hébergement des archives ccns sur le cluster kubernetes avec une limite de volumes par noeud disponnible => permet de réunir au sein d'un même réseau l'ensemble des serveur php sans conflit de ports sur ce même réseau